### PR TITLE
fix: fix updatedHook error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,12 @@ const updatedHook = (el, binding) => {
   });
 
   // Vue event if anything is updated
-  Object.keys(binding.oldValue).forEach((key) => {
-    vueDragEvent(el, `update-${key}`);
-  });
+  // binding.oldValue will be undefined when ref is used in setup
+  if (binding.oldValue) {
+    Object.keys(binding.oldValue).forEach((key) => {
+      vueDragEvent(el, `update-${key}`);
+    });
+  }
 
   // Add draggable configuration to element
   dragSetup(el, binding);


### PR DESCRIPTION
when I used ref in setup, I got this wrong:
`<script setup>
import { onMounted, ref } from 'vue'
const test = ref(123)
onMounted(() => {
    test.value = 444444
})
</script>`
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/49339389/183037688-2ac74d86-7dc0-4dda-bbc0-cf136b88bdb0.png">
